### PR TITLE
Fix FAISS rebuild global assignment

### DIFF
--- a/app.py
+++ b/app.py
@@ -174,9 +174,8 @@ vector_store = None
 
 
 def rebuild_faiss():
-    """
-    Rebuild the FAISS vector store from the documents in document_mapping.json.
-    """
+    """Rebuild the FAISS vector store from ``document_mapping.json``."""
+    global vector_store, document_mapping
     try:
         # Initialize FAISS vector store
         sample_embedding = embeddings.embed_query("test")


### PR DESCRIPTION
## Summary
- ensure `rebuild_faiss` updates the global vector store

## Testing
- `black --check --line-length 120 .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861de55a460832b94d7782d7d9120da