### PR TITLE
Fix startup failure when API key missing

### DIFF
--- a/app.py
+++ b/app.py
@@ -84,8 +84,11 @@ cache = TTLCache(maxsize=1000, ttl=3600)  # 1-hour TTL
 # =====================
 
 
-# Initialize OpenAI API key
-openai.api_key = os.getenv("OPENAI_API_KEY")
+# Initialize OpenAI API key and validate presence
+openai_api_key = os.getenv("OPENAI_API_KEY")
+if not openai_api_key:
+    raise RuntimeError("OPENAI_API_KEY environment variable is required")
+openai.api_key = openai_api_key
 
 
 def allowed_file(filename):
@@ -121,6 +124,7 @@ llm = ChatOpenAI(
     model_name="gpt-4o",
     # model_name="o1-mini",
     streaming=True,  # Enable streaming
+    openai_api_key=openai_api_key,
 )
 
 conversation = ConversationChain(llm=llm, memory=memory)


### PR DESCRIPTION
## Summary
- validate `OPENAI_API_KEY` before starting
- pass the key directly to `ChatOpenAI`

## Testing
- `black --check --line-length 120 .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861e14b1920832ba53fc9b28fdc5f9b