### PR TITLE
Add chat navigation link on upload page

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -21,6 +21,7 @@
     <div class="header">
         <h1>DocuChat</h1>
         <div class="header-buttons">
+            <a href="{{ url_for('chat') }}">Chat</a>
             <a href="{{ url_for('upload_page') }}">Upload Documents</a>
             <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
         </div>

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -14,9 +14,7 @@ import app
 @pytest.fixture(autouse=True)
 def _patch_external(monkeypatch):
     monkeypatch.setattr(app, "get_gpt_response", lambda *args, **kwargs: "mocked")
-    monkeypatch.setattr(
-        app, "get_gpt_response_stream", lambda *args, **kwargs: iter(["mocked"])
-    )
+    monkeypatch.setattr(app, "get_gpt_response_stream", lambda *args, **kwargs: iter(["mocked"]))
     # do not rebuild FAISS during tests
     monkeypatch.setattr(app, "rebuild_faiss", lambda *args, **kwargs: None)
 

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+import app
+
+
+@pytest.fixture(autouse=True)
+def _patch_external(monkeypatch):
+    monkeypatch.setattr(app, "get_gpt_response", lambda *args, **kwargs: "mocked")
+    monkeypatch.setattr(app, "get_gpt_response_stream", lambda *args, **kwargs: iter(["mocked"]))
+    monkeypatch.setattr(app, "rebuild_faiss", lambda *args, **kwargs: None)
+
+
+def create_client():
+    app.app.config["TESTING"] = False
+    return app.app.test_client()
+
+
+def test_upload_page_has_chat_link():
+    client = create_client()
+    response = client.get("/upload_page")
+    assert response.status_code == 200
+    assert b'href="/chat"' in response.data


### PR DESCRIPTION
## Summary
- add navigation link to return from upload page to chat
- test that upload page exposes chat link

## Testing
- `black --check --line-length 120 .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68959e1df2e8832bb6144d01a512ceb0