### PR TITLE
Prepare PR: commit local changes and test updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,38 @@
-# Guidelines for contributors
+# Repository Guidelines
 
-This repository hosts a simple Flask-based chatbot. Follow these conventions when making changes.
+This project is a Flask-based chatbot that integrates OpenAI via LangChain, FAISS for retrieval, and a simple web UI. Use this guide to contribute efficiently and consistently.
 
-## Coding Style
-- Format all Python code with `black` using a line length of 120.
-- Write clear docstrings for new functions or classes.
-- Keep imports sorted and remove unused imports.
+## Project Structure & Module Organization
+- `app.py`: Main Flask app, routes, LangChain/FAISS wiring.
+- `templates/` and `static/`: Jinja templates and assets for the UI.
+- `tests/`: Pytest suite (files named `test_*.py`).
+- `docs/`: Architectural/technical docs.
+- Runtime data: `data/` (FAISS index, caches) and `uploads/` are created on demand.
 
-## Required Checks
-Before submitting changes run:
+## Build, Test, and Development Commands
+- Install: `pip install -r requirements.txt`
+- Run dev server: `python app.py` (binds to port 5000)
+- Lint: `flake8`
+- Format (check): `black --check .` (format with `black .`)
+- Tests: `pytest -q`
+- Docker: `docker build -t docuchat .` then `docker run -p 5000:5000 -e OPENAI_API_KEY=... -e SECRET_KEY=... docuchat`
 
-1. `black --check .`
-2. `flake8`
-3. `pytest -q`
+## Coding Style & Naming Conventions
+- Formatter: `black` with line length 120.
+- Linting: `flake8` (see `.flake8` for rules). Remove unused imports; keep imports sorted.
+- Docstrings: Add clear, concise docstrings to new functions/classes.
+- Naming: `snake_case` for functions/variables, `PascalCase` for classes, `UPPER_SNAKE_CASE` for constants.
 
-All checks should pass.
+## Testing Guidelines
+- Framework: `pytest` with tests under `tests/` named `test_*.py`.
+- Write unit tests for new routes, helpers, and error paths.
+- Run `pytest -q` locally; avoid network calls in tests (use `monkeypatch` as in existing tests).
 
-## Pull Requests
-Summarize your changes and reference relevant lines. Mention the outcome of the checks in the PR body.
+## Commit & Pull Request Guidelines
+- Commits: Use clear, imperative messages (e.g., "Add upload validation"). Group related changes.
+- PRs: Describe the change, rationale, and touchpoints (files/lines). Include results of `black --check .`, `flake8`, and `pytest -q`.
+- Scope: Keep PRs focused. Include screenshots for UI changes when relevant.
+
+## Security & Configuration
+- Required env vars: `OPENAI_API_KEY`, `SECRET_KEY` (use a `.env` locally; never commit secrets).
+- Be mindful of logging; avoid printing sensitive data. Large files are limited to 16MB by default.

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -14,7 +14,9 @@ import app
 @pytest.fixture(autouse=True)
 def _patch_external(monkeypatch):
     monkeypatch.setattr(app, "get_gpt_response", lambda *args, **kwargs: "mocked")
-    monkeypatch.setattr(app, "get_gpt_response_stream", lambda *args, **kwargs: iter(["mocked"]))
+    monkeypatch.setattr(
+        app, "get_gpt_response_stream", lambda *args, **kwargs: iter(["mocked"])
+    )
     # do not rebuild FAISS during tests
     monkeypatch.setattr(app, "rebuild_faiss", lambda *args, **kwargs: None)
 

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -12,7 +12,9 @@ import app
 @pytest.fixture(autouse=True)
 def _patch_external(monkeypatch):
     monkeypatch.setattr(app, "get_gpt_response", lambda *args, **kwargs: "mocked")
-    monkeypatch.setattr(app, "get_gpt_response_stream", lambda *args, **kwargs: iter(["mocked"]))
+    monkeypatch.setattr(
+        app, "get_gpt_response_stream", lambda *args, **kwargs: iter(["mocked"])
+    )
     monkeypatch.setattr(app, "rebuild_faiss", lambda *args, **kwargs: None)
 
 


### PR DESCRIPTION
This PR commits pending local changes and synchronizes with the latest `master`.

Changes
- Update `app.py` with conversation chain/memory wiring tweaks.
- Refresh `AGENTS.md` guidance.
- Adjust tests: `tests/test_error_handling.py`, `tests/test_navigation.py`.

Rationale
- Capture local edits in a dedicated branch and integrate upstream changes cleanly.

Results
- black --check: see below
- flake8: see below
- pytest: see below

Notes
- Rebased on top of `origin/master` with no conflicts.

black --check output:
```
would reformat /home/andrew/codexcli/flask_gpt_chatbot/app.py

Oh no! 💥 💔 💥
1 file would be reformatted, 2 files would be left unchanged.
```

flake8 output:
```

```

pytest output:
```
.......                                                                  [100%]
=============================== warnings summary ===============================
../../.local/lib/python3.10/site-packages/faiss/loader.py:6
  /home/andrew/.local/lib/python3.10/site-packages/faiss/loader.py:6: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    from distutils.version import LooseVersion

tests/test_navigation.py::test_upload_page_has_chat_link
  /home/andrew/codexcli/flask_gpt_chatbot/app.py:244: LangChainDeprecationWarning: Please see the migration guide at: https://python.langchain.com/docs/versions/migrating_memory/
    memory = ConversationBufferMemory()

tests/test_navigation.py::test_upload_page_has_chat_link
  /home/andrew/codexcli/flask_gpt_chatbot/app.py:245: LangChainDeprecationWarning: The class `ConversationChain` was deprecated in LangChain 0.2.7 and will be removed in 1.0. Use :class:`~langchain_core.runnables.history.RunnableWithMessageHistory` instead.
    conversation = ConversationChain(llm=llm, memory=memory)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
7 passed, 3 warnings in 1.18s
```
